### PR TITLE
feat: added silentSso call, to ensure isAuthenticated gets true after page refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@azure/msal-browser": "^2.19.0",
-    "@azure/msal-react": "^1.1.1",
+    "@azure/msal-browser": "^2.20.0",
+    "@azure/msal-react": "^1.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3"

--- a/src/authConfig.js
+++ b/src/authConfig.js
@@ -2,7 +2,8 @@ export const msalConfig = {
     auth: {
         clientId: "e35cbc3c-7055-43a2-b978-d8d24a040140",
         authority: "https://login.mytapio.one/32896ed7-d559-401b-85cf-167143d61be0/B2C_1A_TAPIO_SIGNIN/", // https://<your-tenant>.b2clogin.com/<your-tenant>.onmicrosoft.com/<your-policyID>
-        redirectUri: "https://tapioone.github.io/tapio-auth-react/", // for dev use http://localhost:3000
+        // redirectUri: "https://tapioone.github.io/tapio-auth-react/", // for dev use http://localhost:3000
+        redirectUri: "http://localhost:3000",
         knownAuthorities: ["https://login.mytapio.one"]
     },
     cache: {

--- a/src/authConfig.js
+++ b/src/authConfig.js
@@ -2,8 +2,7 @@ export const msalConfig = {
     auth: {
         clientId: "e35cbc3c-7055-43a2-b978-d8d24a040140",
         authority: "https://login.mytapio.one/32896ed7-d559-401b-85cf-167143d61be0/B2C_1A_TAPIO_SIGNIN/", // https://<your-tenant>.b2clogin.com/<your-tenant>.onmicrosoft.com/<your-policyID>
-        // redirectUri: "https://tapioone.github.io/tapio-auth-react/", // for dev use http://localhost:3000
-        redirectUri: "http://localhost:3000",
+        redirectUri: "https://tapioone.github.io/tapio-auth-react/", // for dev use http://localhost:3000
         knownAuthorities: ["https://login.mytapio.one"]
     },
     cache: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,24 +2,24 @@
 # yarn lockfile v1
 
 
-"@azure/msal-browser@^2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-2.19.0.tgz#6915d200e0679eb8b26368bf0e0fc02ee4a8617a"
-  integrity sha512-nVMMSbFeocGv3SUYGBD+3pkE/pbAciGhER3KCjsBu6Sy9EDaBCiQ418KZfHBcCcrNQgFxf3nleWdeYoYX7281g==
+"@azure/msal-browser@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-2.20.0.tgz#78e34395048c4a8842400d4168b2fb3bdd3c854e"
+  integrity sha512-Fl8boo38fPNlEm84fRCulbTfHJo+Z/i+1gcdJTG+PqmrkMOUVTdpkwznGh6ZQdAM34uumEgzukmqMr8lVKrytA==
   dependencies:
-    "@azure/msal-common" "^5.1.0"
+    "@azure/msal-common" "^5.2.0"
 
-"@azure/msal-common@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-5.1.0.tgz#e3a75a8ba1602da040698046161961d6dc59bbc4"
-  integrity sha512-4zHZ5Ec7jAgTIWZO3ap1ozgIPGAirF1wL8UhsmPF9QDoZz0cMHdaNmtov5i2+6Xq37YMzhN5s50EFHBuXd7sDQ==
+"@azure/msal-common@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-5.2.0.tgz#49440e04f4d0961fc5a1a1718fbe5e4eae2db5db"
+  integrity sha512-oVc4soy5MEZOp9NvCDqBk57mtiUTJXQQ8Z8S/4UiRQP8RG8snuCFQUs9xxdIfvl2FWIvgiBz+SMByyjTaRX42Q==
   dependencies:
     debug "^4.1.1"
 
-"@azure/msal-react@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@azure/msal-react/-/msal-react-1.1.1.tgz#d7980647f6929fd94ca34fa453cd4e5bf3210bb3"
-  integrity sha512-tsl+5N/YQM55E8D5YaolZyxaf70frj/BS8EjZQvmPcxpuyOtQ+qKcJZNL7FYetk30eba58IRUcKNmaVxOJ30xQ==
+"@azure/msal-react@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@azure/msal-react/-/msal-react-1.1.2.tgz#bde82a42c18ec6c6dc5de0dbcea0281a28fec223"
+  integrity sha512-iSHhzCbHs7S+cOnBCKA+4MjwcRxJhsMCUw6XcIkzZqWW1vvQb1k0yy3EL6jfTnlD8uXSNxGOum3Gltmdq7TqEg==
 
 "@babel/code-frame@7.10.4":
   version "7.10.4"


### PR DESCRIPTION
When logging into the application and refreshing the page, you need to click `Login` again, to be authenticated. The click on login will lead to a short (mostly too fast to see) redirect.  
I think it's fairly uncommon for users to click 'Login' again after a page refresh, or when navigating to an application via link, which they just authenticated for in e.g. a different tab.

As a developer following this sample, I am expecting `isAuthenticated` to return `true` after a page refresh or when navigating to the same app via link (assuming that i just logged in some minutes ago). 
I read through msal docs and stumbled upon the `ssoSilent` function, which the docs of msal also exactly point out for the use case of "being already logged in, but don't want to redirect" (see [https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/login-user.md#silent-login-with-ssosilent](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/login-user.md#silent-login-with-ssosilent)).

We did not face this issue for our applications, since we have axios interceptors that acquire an access token silently, which leads to the same behaviour of setting `isAuthenticated` to `true`, since a session at is B2C already existing. 

I extended the sample to contain some example logic + comments on why you might want to do this.

